### PR TITLE
Fix REST wrapper forwarding bad args

### DIFF
--- a/src/feathers/express.cljs
+++ b/src/feathers/express.cljs
@@ -21,5 +21,5 @@
 (defn error-handler [app & [opts]]
   (.use app (exp/errorHandler opts)))
 
-(defn rest [app & [opts]]
-  (.configure app (expr opts)))
+(defn express-rest [app & opts]
+  (.configure app (apply expr opts)))


### PR DESCRIPTION
Fixes degree9/featherscript#23.

- @expressjs/express/rest takes an optional arg to override request formatter
- express/rest was always provides a nil value if formatter was not supplied in opts list

There's likely 100 ways to solve this problem in a simple way. This was the first seemingly not terrible one that jumped into my mind. I could be wrong but at least it was working in my tests.